### PR TITLE
added updateNotification feature under same notification pointer

### DIFF
--- a/src/main/java/es/blackleg/jlibnotify/LibNotify.java
+++ b/src/main/java/es/blackleg/jlibnotify/LibNotify.java
@@ -41,6 +41,10 @@ public interface LibNotify {
 
     void showNotification(Notification notification);
 
+    void updateNotification(Notification notification, String summary, String body, String icon);
+
+    void setTimeOut(Notification notification, int timeout);
+
     void closeNotification(Notification notification);
     
 }

--- a/src/main/java/es/blackleg/jlibnotify/core/DefaultLibNotify.java
+++ b/src/main/java/es/blackleg/jlibnotify/core/DefaultLibNotify.java
@@ -30,7 +30,7 @@ import java.util.Collection;
 public class DefaultLibNotify implements LibNotify {
 
     private final NativeLibNotify nativeLibNotify;
-    
+
     private final ServerCapabilitiesReader serverCapabilitiesReader;
 
     public DefaultLibNotify(NativeLibNotify libNotify, ServerCapabilitiesReader serverCapabilitiesReader) {
@@ -54,7 +54,7 @@ public class DefaultLibNotify implements LibNotify {
     public void unInit() {
         nativeLibNotify.notify_uninit();
     }
-    
+
     @Override
     public String getAppName() {
         return nativeLibNotify.notify_get_app_name();
@@ -64,21 +64,21 @@ public class DefaultLibNotify implements LibNotify {
     public void setAppName(String appName) {
         nativeLibNotify.notify_set_app_name(appName);
     }
-    
+
     @Override
     public ServerInfo getServerInfo() {
         String[] name = new String[1];
         String[] vendor = new String[1];
         String[] version = new String[1];
         String[] specVersion = new String[1];
-        
+
         if (nativeLibNotify.notify_get_server_info(name, vendor, version, specVersion)== GBoolean.FALSE) {
             throw new RuntimeException("Error when get server info");
         }
-        
+
         return new BasicServerInfo(name[0], vendor[0], version[0], specVersion[0]);
     }
-    
+
     @Override
     public Collection<String> getServerCapabilities() {
         return serverCapabilitiesReader.getServerCapabilitiesFromPointer(nativeLibNotify.notify_get_server_caps());
@@ -95,6 +95,18 @@ public class DefaultLibNotify implements LibNotify {
         if (nativeLibNotify.notify_notification_show(notification.getPointer(), Pointer.NULL) == GBoolean.FALSE) {
             throw new RuntimeException("Error when show notification");
         }
+    }
+
+    @Override
+    public void updateNotification(Notification notification, String summary, String body, String icon) {
+        if ( nativeLibNotify.notify_notification_update(notification.getPointer(), summary, body, icon) == GBoolean.FALSE) {
+            throw new RuntimeException("Error when showing notification");
+        }
+    }
+
+    @Override
+    public void setTimeOut(Notification notification, int timeout) {
+        nativeLibNotify.notify_notification_set_timeout(notification.getPointer(), timeout);
     }
 
     @Override

--- a/src/main/java/es/blackleg/jlibnotify/jna/NativeLibNotify.java
+++ b/src/main/java/es/blackleg/jlibnotify/jna/NativeLibNotify.java
@@ -33,15 +33,19 @@ public interface NativeLibNotify extends Library {
     String notify_get_app_name();
     
     void notify_set_app_name(String app_name);
-    
+
+    void notify_notification_set_timeout(Pointer notification, int timeout);
+
     GBoolean notify_get_server_info(String[] ret_name, String[] ret_vendor, String[] ret_version, String[] ret_spec_version);
-    
+
     Pointer notify_get_server_caps();
-    
+
     Pointer notify_notification_new(String summary, String body, String icon);
-    
+
     GBoolean notify_notification_show(Pointer notification, Pointer error);
-    
+
+    GBoolean notify_notification_update(Pointer notification, String summary, String body, String icon);
+
     GBoolean notify_notification_close(Pointer notification, Pointer error);
-    
+
 }

--- a/src/test/java/es/blackleg/jlibnotify/LibNotifyIT.java
+++ b/src/test/java/es/blackleg/jlibnotify/LibNotifyIT.java
@@ -80,10 +80,12 @@ public class LibNotifyIT {
         assertThat(notification).isNotNull();
         
         libNotify.showNotification(notification);
-        
+        libNotify.setTimeOut(notification,1000);
+        //Thread.sleep(1000);
+        libNotify.updateNotification(notification, "LibNotify IT override","LibNotify Integration test override", "dialog-information");
+        libNotify.showNotification(notification);
         Thread.sleep(1000);
-        
         libNotify.closeNotification(notification);
     }
-    
+
 }

--- a/src/test/java/es/blackleg/jlibnotify/test/NativeLibNotifyMock.java
+++ b/src/test/java/es/blackleg/jlibnotify/test/NativeLibNotifyMock.java
@@ -24,8 +24,9 @@ import es.blackleg.jlibnotify.jna.NativeLibNotify;
  * @author Hector Espert <hectorespertpardo@gmail.com>
  */
 public class NativeLibNotifyMock implements NativeLibNotify {
-    
+
     private String appName;
+    private int timeout;
 
     @Override
     public GBoolean notify_init(String appName) {
@@ -54,6 +55,11 @@ public class NativeLibNotifyMock implements NativeLibNotify {
     }
 
     @Override
+    public GBoolean notify_notification_update(Pointer notification, String summary, String body, String icon) {
+        return GBoolean.TRUE;
+    }
+
+    @Override
     public GBoolean notify_notification_close(Pointer notification, Pointer error) {
         return GBoolean.TRUE;
     }
@@ -66,6 +72,11 @@ public class NativeLibNotifyMock implements NativeLibNotify {
     @Override
     public void notify_set_app_name(String appName) {
         this.appName = appName;
+    }
+
+    @Override
+    public void notify_notification_set_timeout(Pointer notification, int timeout) {
+        this.timeout = timeout;
     }
 
     @Override


### PR DESCRIPTION
Hi hectorespert,

Thank you for creating this library. Using this, I am able to send notification via java app. 

I have added updateNotification() feature under same notification pointer as it was available in [libnotify](https://developer.gnome.org/libnotify/unstable/NotifyNotification.html).

Assuming that a button is set to call the notification via this wrapper, pressing the button repeatedly doesnot update the instant notification. Yes, If we disable Thread.sleep() before closeNotification(), the notification will not show up, as closeNotification() is being instantly called after showNotification() is called. And if we disable both Thread.sleep() and closeNotification(), the notification will take its own time to close and the repetitive button clicks/press will stack up notifications, as every time a new notification pointer is created even though messages are updated. So I wanted to have updateNotification() as well so that the notification pointers will not stack up.

This is the implementation such that libnotify notifications will not stack up. Instead they will be overridden instantly on calling notifyMe().
```
    static LibNotify libNotify = DefaultLibNotifyLoader.getInstance().load();
    static Notification notification = libNotify.createNotification("Subject", "Message", "dialog-information");

    private static void NotifyMe(String title,String msg) {
        libNotify.init("NotifyMe");
        libNotify.updateNotification(notification, title, msg, "dialog-information");
        libNotify.closeNotification(notification);
        libNotify.showNotification(notification);
    }
```

I also have added setTimeOut() as well but this is not working in my arch linux cinnamon desktop environment. 

Thank you,
